### PR TITLE
declare minor version of Compose file explicitly

### DIFF
--- a/docker-compose.override-for-docker-sync.yml
+++ b/docker-compose.override-for-docker-sync.yml
@@ -2,7 +2,7 @@
 # The setting is for the development environment.
 # @see https://docs.docker.com/compose/extends/
 
-version: '3'
+version: '3.8'
 
 services:
   db:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@
 # The setting is for the development environment.
 # @see https://docs.docker.com/compose/extends/
 
-version: '3'
+version: '3.8'
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 
 services:
   db:


### PR DESCRIPTION
After this changes, we have to use Docker Engine release 19.03.0+.
https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix